### PR TITLE
activity: created service to reset counter

### DIFF
--- a/ros2-for-beginners/ros2_ws/src/test_py_pkg/test_py_pkg/number_counter.py
+++ b/ros2-for-beginners/ros2_ws/src/test_py_pkg/test_py_pkg/number_counter.py
@@ -3,7 +3,7 @@
 import rclpy
 from rclpy.node import Node
 from example_interfaces.msg import Int64
-
+from example_interfaces.srv import SetBool
 
 
 class NumberCounterNode(Node):
@@ -15,6 +15,10 @@ class NumberCounterNode(Node):
             Int64, "number_count", 10)
         self.number_subscriber_ = self.create_subscription(
             Int64, "number", self.subcription_callback, 10)
+
+        self.reset_counter_server_ = self.create_service(
+            SetBool, "reset_counter", self.callback_reset_counter
+        )
 
         self.get_logger().info("Number Counter Node started")
 
@@ -29,6 +33,32 @@ class NumberCounterNode(Node):
         new_msg.data = self.counter_
         self.counter_publisher_.publish(new_msg)
 
+    """
+    for a service 
+        1. define an instance  - (srv_type,srv_name,callback)
+        2. define a callback - (request, response)
+    """
+
+    def callback_reset_counter(self, request, response):
+        try:
+            if (request.data):
+                self.counter_ = 0
+                response.success = True
+                response.message = "successfull reset counter"
+                self.get_logger().error(
+                    f"reset success --> counter : {self.counter_}")
+            else:
+                response.success = True
+                response.message = "counter value not requested to reset"
+                self.get_logger().warn(
+                    f"reset not requested --> counter : {self.counter_}")
+            return response
+        except Exception as e:
+            response.success = False
+            response.message = "Exception in reset counter"
+            self.get_logger().error(
+                f"reset failed --> counter : {self.counter_}")
+            return response
 
 
 def main(args=None):

--- a/ros2-for-beginners/ros2_ws/src/test_py_pkg/test_py_pkg/number_publisher.py
+++ b/ros2-for-beginners/ros2_ws/src/test_py_pkg/test_py_pkg/number_publisher.py
@@ -6,7 +6,6 @@ from rclpy.node import Node
 from example_interfaces.msg import Int64
 
 
-
 class NumberPubliserNode(Node):
     def __init__(self) -> None:
         super().__init__("number_publisher")
@@ -19,7 +18,6 @@ class NumberPubliserNode(Node):
         msg = Int64()
         msg.data = self.number_
         self.number_publisher_.publish(msg)
-
 
 
 def main(args=None):


### PR DESCRIPTION
- [x] created a service in `number_counter` node
- [x] the service has to be invoked from the terminal 
- [x] successfully resets the `counter_` if the `data = True` for the incoming `SetBool` service message type.

closes #32  